### PR TITLE
GDB-3301 Changed creation of shaded jar to be activated -DcreateShade…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,15 +176,6 @@
             </plugin>
 
         </plugins>
-
-	    <extensions>
-        <!--Enabling the use of FTP-->
-			  <extension>
-				  <groupId>org.apache.maven.wagon</groupId>
-				  <artifactId>wagon-ftp</artifactId>
-				  <version>1.0-beta-6</version>
-			  </extension>
-        </extensions>
     </build>
     
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,15 @@
             </plugin>
 
         </plugins>
+
+	    <extensions>
+        <!--Enabling the use of FTP-->
+			  <extension>
+				  <groupId>org.apache.maven.wagon</groupId>
+				  <artifactId>wagon-ftp</artifactId>
+				  <version>1.0-beta-6</version>
+			  </extension>
+        </extensions>
     </build>
     
     <profiles>
@@ -211,6 +220,12 @@
         <profile>
             <!-- In order to activate shading plugin (e.g., to generate an end-user-friendly uber-jar), run "mvn package -P endUserRelease" -->
             <id>endUserRelease</id>
+            <activation>
+                <property>
+                    <!-- "mvn deploy -DcreateShadedJar" will upload shaded jar in our maven repository -->
+                    <name>createShadedJar</name>
+                </property>
+            </activation>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
…dJar (e.g "mvn deploy -DcreateShadedJar" will create and upload shaded jar in our maven repository). Old creation of shaded jar is preserved.